### PR TITLE
:recycle: add `TimeSeries` values for devices

### DIFF
--- a/common/device.proto
+++ b/common/device.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+import "google/protobuf/timestamp.proto";
+
 package device;
 
 message Value {
@@ -13,7 +15,7 @@ message Value {
 
     message TimeSeries {
 	message Entry {
-	    double stamp = 1;
+	    google.protobuf.Timestamp stamp = 1;
 	    double value = 2;
 	}
 


### PR DESCRIPTION
This proposes a time-series time to be returned by a device.

This type should allow us to directly support EPICS's time-series, normative type. It can also be a "virtual" return type in that DPM could return this type when returning high-speed plot data from a scalar device.