### PR TITLE
:recycle: change to the setting API

### DIFF
--- a/services/DAQ.proto
+++ b/services/DAQ.proto
@@ -14,7 +14,7 @@ import "common/status.proto";
 
 service DAQ {
     rpc Read(ReadingList) returns (stream ReadingReply) {}
-    rpc Set(SettingList) returns (stream SettingReply) {}
+    rpc Set(SettingList) returns (SettingReply) {}
 }
 
 message ReadingList {
@@ -53,7 +53,5 @@ message SettingList {
 }
 
 message SettingReply {
-    uint32 index = 1;
-    common.status.Status status = 2;
+    repeated common.status.Status status = 2;
 }
-


### PR DESCRIPTION
We send an array of settings but were returning a stream of replies. This meant every gRPC client had to correlate the replies.

This commit makes the setting API a request/reply transaction and DPM will return the array of statuses.