### PR TITLE
:bug: fix layout

### DIFF
--- a/common/device.proto
+++ b/common/device.proto
@@ -1,17 +1,44 @@
+// Defines a message that can represent any type used by ACNET and
+// EPICS devices.
+//
+// Protocols that need to receive or provide device data should import
+// this file so they have an up-to-date representation of the device
+// types we're using. As we add more types, dependent protocols will
+// add them to their set (when rebuilt.)
+
 syntax = "proto3";
 
 import "google/protobuf/timestamp.proto";
 
 package common.device;
 
+// Holds a value that can be sent to a device to be received by
+// reading a device.
+
 message Value {
+
+    // Represents an array of floating point values.
+    //
+    // This needs to be a message because `oneof` fields don't allow
+    // the `repeated` keyword to be specified. This message type is
+    // used for ACNET array devices and EPICS waveform PVs.
+
     message ScalarArray {
         repeated double value = 1;
     }
 
+    // Represents an array of strings.
+    //
+    // This needs to be a message because `oneof` fields don't allow
+    // the `repeated` keyword to be specified.
+
     message TextArray {
         repeated string value = 1;
     }
+
+    // Represents an array of timestamp/data pairs.
+    //
+    // This message type is used for EPICS time-series PVs.
 
     message TimeSeries {
 	message Entry {
@@ -21,6 +48,10 @@ message Value {
 
 	repeated Entry entry = 1;
     }
+
+    // DEPRECATED. A message which is opinionated towards ACNET analog
+    // alarm structures. This will be replaced by a message that can
+    // represent both ACNET and EPICS alarms.
 
     message AnalogAlarm {
 	option deprecated = true;
@@ -34,6 +65,10 @@ message Value {
         uint32 triesNow = 8;
     }
 
+    // DEPRECATED. A message which is opinionated towards ACNET
+    // digital alarm structures. This will be replaced by a message
+    // that can represent both ACNET and EPICS alarms.
+
     message DigitalAlarm {
 	option deprecated = true;
         int32 nominal = 1;
@@ -46,10 +81,16 @@ message Value {
         uint32 triesNow = 8;
     }
 
+    // DEPRECATED. A message which is opinionated towards ACNET status
+    // definitions. This will be replaced by a more generic message
+    // that can be used by ACNET and EPICS devices.
+
     message BasicStatus {
 	option deprecated = true;
         map<string, string> value = 1;
     }
+
+    // A device value can only be one of these types.
 
     oneof value {
         double scalar = 1;

--- a/common/device.proto
+++ b/common/device.proto
@@ -23,6 +23,7 @@ message Value {
     }
 
     message AnalogAlarm {
+	option deprecated = true;
         double minimum = 1;
         double maximum = 2;
         bool alarmEnable = 3;
@@ -34,6 +35,7 @@ message Value {
     }
 
     message DigitalAlarm {
+	option deprecated = true;
         int32 nominal = 1;
         uint32 mask = 2;
         bool alarmEnable = 3;
@@ -45,6 +47,7 @@ message Value {
     }
 
     message BasicStatus {
+	option deprecated = true;
         map<string, string> value = 1;
     }
 
@@ -54,9 +57,9 @@ message Value {
         bytes raw = 3;
         string text = 4;
         TextArray textArr = 5;
-        AnalogAlarm anaAlarm = 6;
-        DigitalAlarm digAlarm = 7;
-        BasicStatus basicStatus = 8;
+        AnalogAlarm anaAlarm = 6 [deprecated = true];
+        DigitalAlarm digAlarm = 7 [deprecated = true];
+        BasicStatus basicStatus = 8 [deprecated = true];
 	TimeSeries series = 9;
     }
 }

--- a/deprecated/dpm.proto
+++ b/deprecated/dpm.proto
@@ -1,0 +1,122 @@
+syntax = "proto3";
+
+option java_multiple_files = false;
+option java_package = "gov.fnal.controls.dpm.proto.grpc";
+option java_outer_classname = "DPMProto";
+
+package dpm;
+
+import "google/protobuf/empty.proto";
+import "google/protobuf/timestamp.proto";
+
+service DPM {
+    rpc OpenSession(google.protobuf.Empty) returns (stream SessionReply) {}
+    rpc Authenticate(AuthRequest) returns (AuthReply) {}
+    rpc ReadDevice(Device) returns (Reading) {}
+    rpc StartAcquisition(AcquisitionList) returns (stream Reading) {}
+    rpc ApplySettings(SettingList) returns (StatusList) {}
+    rpc GetData(google.protobuf.Timestamp) returns (stream Reading) {}
+}
+
+message Result {
+    oneof value {
+	google.protobuf.Empty none = 1;
+	string error = 2;
+    }
+}
+
+message SessionReply {
+    string sessionId = 1;
+    string serviceName = 2;
+}
+
+message AuthRequest {
+    string sessionId = 1;
+    bytes token = 2;
+}
+
+message AuthReply {
+    oneof step {
+	bytes token = 1;
+	Result result = 2;
+    }
+}
+
+message Device {
+    string sessionId = 1;
+    string name = 2;
+}
+
+message AcquisitionList {
+    string sessionId = 1;
+    repeated string req = 2;
+}
+
+message Data {
+    message ScalarArray {
+        repeated double value = 1;
+    }
+
+    message TextArray {
+        repeated string value = 1;
+    }
+
+    message AnalogAlarm {
+        double minimum = 1;
+        double maximum = 2;
+        bool alarmEnable = 3;
+        bool alarmStatus = 4;
+        bool abort = 5;
+        bool abortInhibit = 6;
+        uint32 triesNeeded = 7;
+        uint32 triesNow = 8;
+    }
+
+    message DigitalAlarm {
+        sint32 nominal = 1;
+        uint32 mask = 2;
+        bool alarmEnable = 3;
+        bool alarmStatus = 4;
+        bool abort = 5;
+        bool abortInhibit = 6;
+        uint32 triesNeeded = 7;
+        uint32 triesNow = 8;
+    }
+
+    message BasicStatus {
+        map<string, string> value = 1;
+    }
+
+    oneof value {
+        sint32 status = 1;	// set when a fatal error occurs
+        double scalar = 2;
+        ScalarArray scalarArr = 3;
+        bytes raw = 4;
+        string text = 5;
+        TextArray textArr = 6;
+        AnalogAlarm anaAlarm = 7;
+        DigitalAlarm digAlarm = 8;
+        BasicStatus basicStatus = 9;
+    }
+}
+
+message Reading {
+    uint64 timestamp = 1;
+    uint32 index = 2;
+    Data data = 3;
+}
+
+message Setting {
+    string name = 1;
+    Data data = 2;
+}
+
+message SettingList {
+    string sessionId = 1;
+    repeated Setting setting = 2;
+    string event = 3;
+}
+
+message StatusList {
+    repeated sint32 status = 1;
+}

--- a/services/DAQ.proto
+++ b/services/DAQ.proto
@@ -1,3 +1,5 @@
+// This protocol is used to read and set accelerator devices.
+
 syntax = "proto3";
 
 option java_multiple_files = false;
@@ -11,27 +13,86 @@ import "google/protobuf/timestamp.proto";
 import "common/device.proto";
 import "common/status.proto";
 
+// The DAQ API.
+//
+// gRPC clients use these to gain access to accelerator devices.
+
 service DAQ {
+
+    // Requests device readings from DPM.
+    //
+    // The parameter contains an array of specifications. Each entry
+    // uses DRF to indicate which device is to be read and at what
+    // rate. DPM will return a stream of readings.
+    //
+    // NOTE: DPM will close the stream when no more data will be
+    // received. For instance, if a request asks for multiple devices
+    // to be read once, DPM will close the stream when every device
+    // has returned one value.
+
     rpc Read(ReadingList) returns (stream ReadingReply) {}
+
+    // In order to set devices, a client needs to provide a JWT along
+    // with the `Set` request. The JWT is passed in the http headers
+    // and will be used by DPM to determine whether the client is
+    // authorized to set the device.
+
     rpc Set(SettingList) returns (SettingReply) {}
 }
+
+// Used as the parameter to the `Read()` request.
+//
+// Contains a list of DRF strings which DPM uses to determine which
+// devices to read and at what sample rate.
 
 message ReadingList {
     repeated string drf = 1;
 }
 
+// One reading of a device.
+
 message Reading {
+    // The UTC timestamp of when the data was sampled.
+
     google.protobuf.Timestamp timestamp = 1;
+
+    // The value read from the device. Note this can be any of the
+    // valid device types that our control system supports.
+
     common.device.Value data = 2;
-    common.status.Status status = 3;
+
+    // An associated status code. Normally 0, but could be a positive
+    // value indicating extra status information. Right now, this maps
+    // to our current ACNET status codes. This field will be dropped
+    // in favor of a control system agnostic status field.
+
+    common.status.Status status = 3 [deprecated = true];
 }
+
+// A container for multiple device readings.
+//
+// Some requests may generate a lot of data. Rather than have a
+// message serialized/deserialized for each data point, we allow DPM
+// to group them in one message. The clients can loop through the
+// results and process them one by one. For slower requests, this
+// array will most likely only ever contain one data point.
 
 message Readings {
     repeated Reading reading = 2;
 }
 
+// One element of the stream returned by `Read()`.
+
 message ReadingReply {
+
+    // Indicates to which entry in the request list this reply
+    // corresponds.
+
     uint32 index = 1;
+
+    // The reply can contain either a reading or a fatal ACNET status
+    // code. If a status code is returned, there will never be another
+    // reply for this index in the stream.
 
     oneof value {
         Readings readings = 2;
@@ -39,14 +100,27 @@ message ReadingReply {
     }
 }
 
+// A setting to be made.
+
 message Setting {
+
+    // The name of the device to be set.
+
     string device = 1;
+
+    // The value to set.
+
     common.device.Value value = 2;
 }
+
+// Holds an array of settings.
 
 message SettingList {
     repeated Setting setting = 1;
 }
+
+// The reply message of `Set()`. Contains an arrays of status
+// values. These correspond to the entries in the setting request.
 
 message SettingReply {
     repeated common.status.Status status = 2;


### PR DESCRIPTION
I'm not sure why the `deprecated` directory was re-arranged the way it was. This repo should simply be a directory tree of `.proto` files. Nothing in it should be specific to a particular target because that defeats the purpose of sharing the files.

I'll leave the `pom.xml` mess alone, as long as it stays in the `deprecated` directory.