### PR TITLE
Remove `TimeSeries` value type

### DIFF
--- a/proto/controls/common/v1/device.proto
+++ b/proto/controls/common/v1/device.proto
@@ -36,19 +36,6 @@ message Value {
         repeated string value = 1;
     }
 
-    // Represents an array of timestamp/data pairs.
-    //
-    // This message type is used for EPICS time-series PVs.
-
-    message TimeSeries {
-	message Entry {
-	    google.protobuf.Timestamp stamp = 1;
-	    double value = 2;
-	}
-
-	repeated Entry entry = 1;
-    }
-
     // DEPRECATED. A message which is opinionated towards ACNET analog
     // alarm structures. This will be replaced by a message that can
     // represent both ACNET and EPICS alarms.

--- a/proto/controls/common/v1/device.proto
+++ b/proto/controls/common/v1/device.proto
@@ -88,6 +88,5 @@ message Value {
         AnalogAlarm anaAlarm = 6 [deprecated = true];
         DigitalAlarm digAlarm = 7 [deprecated = true];
         BasicStatus basicStatus = 8 [deprecated = true];
-	TimeSeries series = 9;
     }
 }


### PR DESCRIPTION
It can be emulated with our array of readings.