### PR TITLE
Add grpc-alarms-db service interface definitions

### DIFF
--- a/proto/controls/service/grpc-alarms-db/v1/alarm-lists.proto
+++ b/proto/controls/service/grpc-alarms-db/v1/alarm-lists.proto
@@ -1,14 +1,13 @@
 syntax = "proto3";
 
 import "google/protobuf/timestamp.proto";
+import "google/protobuf/empty.proto";
 
-package alarmlists;
+package services.alarmLists;
 
 service AlarmListService {
-    rpc getAlarmLists(EmptyRequest) returns (AlarmLists);
+    rpc getAlarmLists(google.protobuf.Empty) returns (AlarmLists);
 }
-
-message EmptyRequest {}
 
 message AlarmList {
     int32 list_number = 1;


### PR DESCRIPTION
This is the initial protobuf definition for the [grpc-alarms-db](https://github.com/fermi-ad/grpc-alarms-db) service. Once in place, that service will be updated to pull its definitions from here (currently hosting its own copy of this file). 