### PR TITLE
Update alarms-db protos for improved API

### DIFF
--- a/proto/controls/service/grpc-alarms-db/v1/alarm-groups.proto
+++ b/proto/controls/service/grpc-alarms-db/v1/alarm-groups.proto
@@ -6,8 +6,20 @@ import "google/protobuf/empty.proto";
 package services.alarm_groups;
 
 service AlarmGroupService {
-    rpc getAllGroups(google.protobuf.Empty) returns (AlarmGroups);
-    rpc getSpecifiedGroups(GroupsRequest) returns (AlarmGroups);
+    rpc getGroupMetadata(google.protobuf.Empty) returns (AlarmGroupMetadata);
+    rpc getGroups(GroupsRequest) returns (AlarmGroups);
+}
+
+message AlarmGroupMetadatum {
+    string name = 1;
+    string description = 2;
+    google.protobuf.Timestamp updated_at = 3;
+    string updated_by = 4;
+    bool is_user_category = 5;
+}
+
+message AlarmGroupMetadata {
+    repeated AlarmGroupMetadatum metadata = 1;
 }
 
 message GroupsRequest {
@@ -15,12 +27,9 @@ message GroupsRequest {
 }
 
 message AlarmGroup {
-    string name = 1;
-    string description = 2;
-    google.protobuf.Timestamp modified_date = 3;
-    string modified_user = 4;
-    repeated string devices = 5;
-    repeated string groups = 6;
+    AlarmGroupMetadatum metadata = 1;
+    repeated string devices = 2;
+    repeated string groups = 3;
 }
 
 message AlarmGroups {


### PR DESCRIPTION
After working with the database a bit more, it became clear that allowing users to easily ask for all alarm groups and all devices associated with them was a bad call. It's a mountain of data, and callers should have to put in some effort to get it. 

Instead, opted to allow callers to ask for the metadata on all groups (name, description, last update time, last user to make an update, and whether the group is a user category for the alarm screen). Callers can then make a separate request to get the contents of one or more groups. 

As this isn't deployed anywhere yet, thought it safe to keep updating v1 instead of making a new API.