### PR TITLE
remove redundant bypass field, update comments

### DIFF
--- a/proto/controls/service/DAQ/v1/DAQ.proto
+++ b/proto/controls/service/DAQ/v1/DAQ.proto
@@ -178,9 +178,9 @@ message Alarm {
     Status status = 1;      //  How alarm criteria are being met (or not)
     Severity severity = 2;  //  How severe is the alarm
     bool enabled = 3;       //  Can this alarm happen? (ACNET bypass=false, EPICS active=true)
-    string text = 5;        //  Description of this alarm
-    string url = 6;         //  Where to get help for this alarm
-    string name = 7;        //  Name for this alarm (unique on device)
+    string text = 4;        //  Description of this alarm
+    string url = 5;         //  Where to get help for this alarm
+    string name = 6;        //  Name for this alarm (unique on device)
     //  priority        //  arbitrary integer for comparing ACNET alarms
     //  sound
     //  speech


### PR DESCRIPTION
remove redundant `bypassed` field (handled by `enabled` filed)
add comments describing some ACNET vs EPICS differences