### PR TITLE
remove unused fields and irrelevant comments

### DIFF
--- a/proto/controls/service/DAQ/v1/DAQ.proto
+++ b/proto/controls/service/DAQ/v1/DAQ.proto
@@ -179,11 +179,4 @@ message Alarm {
     Severity severity = 2;  //  How severe is the alarm
     bool enabled = 3;       //  Can this alarm happen? (ACNET bypass=false, EPICS active=true)
     string text = 4;        //  Description of this alarm
-    string url = 5;         //  Where to get help for this alarm
-    string name = 6;        //  Name for this alarm (unique on device)
-    //  priority        //  arbitrary integer for comparing ACNET alarms
-    //  sound
-    //  speech
-    //  handler code    //  ACNET concept ?
-    //  acknowledged and snoozed are not front end concepts
 }


### PR DESCRIPTION
Remove fields that are not part of an alarm occurrence on the front-end.

They are either part of the alarm definition (i.e. in the device database) or they are concepts managed by an alarm server (snooze, acknowledge, priority).

Since the purpose of this interface is to query information about an alarm occurrence from the front-end, these fields are not necessary.