### PR TITLE
Corrected DeviceAlarmTextList's member - now in snake case.

### DIFF
--- a/proto/controls/service/DevDB/v1/DevDB.proto
+++ b/proto/controls/service/DevDB/v1/DevDB.proto
@@ -162,7 +162,7 @@ message DeviceAlarmText {
 }
 
 message DeviceAlarmTextList {
-    repeated DeviceAlarmText deviceAlarmText = 1;
+    repeated DeviceAlarmText device_alarm_text = 1;
 }
 
 message AlarmInfo {


### PR DESCRIPTION
Corrected DeviceAlarmTextList's member - now in snake case.