### PR TITLE
Create workflow to trigger other repos on proto update

### DIFF
--- a/.github/workflows/notify-proto-update.yaml
+++ b/.github/workflows/notify-proto-update.yaml
@@ -20,9 +20,14 @@ jobs:
           app-id: ${{ vars.ACTION_SETTINGS_APP_ID }}
           private-key: ${{ secrets.ACTION_SETTINGS_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+
       - name: Repository Dispatch
-        uses: peter-evans/repository-dispatch@v3
-        with:
-          token: ${{ steps.generate-token.outputs.token }}
-          repository: ${{ matrix.repo }}
-          event-type: protos-updated # This is the key used to subscribe to these notifications
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: |
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/${{ matrix.repo }}/dispatches \
+            -f event_type='protos-updated'


### PR DESCRIPTION
Here's an example of how I'm using this for `grpc-reflection-catalog`.
```remote-update.yaml
name: Remote Interface Update

on:
  # https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#repository_dispatch
  repository_dispatch:
    types: [protos-updated]
  workflow_dispatch: # Allows you to trigger manually from the UI

jobs:
  update-submodule:
    runs-on: ubuntu-latest
    steps:
      - name: Checkout
        uses: actions/checkout@v4
        with:
          submodules: true
          token: ${{ secrets.GITHUB_TOKEN }}

      - name: Update Submodule
        run: |
          git submodule update --remote interface-definitions
          git config --global user.name "github-actions[bot]"
          git config --global user.email "github-actions[bot]@users.noreply.github.com"
          if [[ -n $(git status -s) ]]; then
            git add interface-definitions
            git commit -m "chore: update interface-definitions submodule"
            git push
          else
            echo "No changes to commit"
          fi

```

This pulls changes from the interface-definitions repo to the local submodule when triggered by these proposed changes.