### PR TITLE
remove DAQ alarms interface that will never be used

### DIFF
--- a/proto/controls/service/DAQ/v1/DAQ.proto
+++ b/proto/controls/service/DAQ/v1/DAQ.proto
@@ -38,10 +38,6 @@ service DAQ {
     // authorized to set the device.
 
     rpc Set(SettingList) returns (SettingReply) {}
-
-    // The parameter contains an array of device names.
-
-    rpc Alarms(DeviceList) returns (AlarmsReply) {}
 }
 
 // Used as the parameter to the `Read()` request.
@@ -132,51 +128,4 @@ message SettingReply {
 
 message DeviceList {
     repeated string device = 1;
-}
-
-message AlarmsReply {
-
-    // Indicates to which entry in the request list this reply
-    // corresponds.
-
-    uint32 index = 1;
-
-    // The reply can contain either a reading or a fatal ACNET status
-    // code. If a status code is returned, there will never be another
-    // reply for this index in the stream.
-
-    oneof value {
-        AlarmList alarms = 2;
-        common.status.Status status = 3;
-    }
-}
-
-message AlarmList {
-    string device = 1;          //  device name for all alarms in list
-    repeated Alarm alarm = 2;
-}
-
-//  Represents the occurence of one of several types of alarms
-//      1) ACNET Analog Alarm
-//      2) ACNET Digital Alarm
-//      3) EPICS PV Alarm
-
-message Alarm {
-    enum Status {
-        STAT_NONE = 0;      //  No alarm
-        STAT_HIHI = 1;      //  Higher than high-high limit
-        STAT_HIGH = 2;      //  Higher than high limit (ACNET does not use)
-        STAT_LOW  = 3;      //  Lower than low limit (ACNET does not use)
-        STAT_LOLO = 4;      //  Lower than low-low limit
-        STAT_BOOL = 5;      //  Boolean alarm (ACNET Digital / EPICS STATE)
-    }
-    enum Severity {
-        SEV_NONE  = 0;      //  No alarm
-        SEV_MINOR = 1;      //  Minor alarm (ACNET event)
-        SEV_MAJOR = 2;      //  Major alarm (ACNET exception)
-    }
-    Status status = 1;      //  How alarm criteria are being met (or not)
-    Severity severity = 2;  //  How severe is the alarm
-    bool enabled = 3;       //  Can this alarm happen? (ACNET bypass=false, EPICS active=true)
-    string text = 4;        //  Description of this alarm
 }


### PR DESCRIPTION
This alarm interface to DPM is not/will not be used - remove it to reduce confusion.