### PR TITLE
Add accelerator alarm schema

### DIFF
--- a/proto/controls/common/v1/alarms.proto
+++ b/proto/controls/common/v1/alarms.proto
@@ -36,28 +36,23 @@ message Status {
     // Indicates which sort of EPICS alarm this is (out of range, lost connection, etc.)
     string epicsAlarmType = 5;
 
-    // Details about the state, including any alarm description if in alarm.
-    string message = 6;
-
     // Filled when the current status state was set by a user. Contains the username
     // of the user who made the change.
-    string user = 7;
+    string user = 6;
 
     // Indicates when an alarm is scheduled to come back into active status from bypass.
-    google.protobuf.Timestamp wake = 8;
+    google.protobuf.Timestamp wake = 7;
 }
 
 message Alarm {
+    enum Source {
+        Source_UNKNOWN = 0;
+        Source_ANALOG = 1;
+        Source_DIGITAL = 2;
+        Source_EPICS = 3;
+    }
+
     string device = 1;
-
-    // --- The following fields should be set according to need. ---
-
-    // An ACNET analog alarm.
-    Status analog = 2;
-
-    // An ACNET digital alarm.
-    Status digital = 3;
-
-    // An EPICS alarm.
-    Status epics = 4;
+    Status status = 2;
+    Source source = 3;
 }


### PR DESCRIPTION
Added a schema for an accelerator alarm, for use by the unified alarms stack.

I imagine this will be folded into whatever we come up with for the alarm server's gRPC endpoints. But as that has not been created yet, stuck it in the `/common` directory.