### PR TITLE
Replace duration_seconds with wake in SnoozeAlarmRequest

### DIFF
--- a/proto/controls/service/grpc-alarm-commands/v1/alarm_commands.proto
+++ b/proto/controls/service/grpc-alarm-commands/v1/alarm_commands.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package services.alarm_commands.v1;
 
 import "google/protobuf/empty.proto";
+import "google/protobuf/timestamp.proto";
 
 service AlarmCommands {
   rpc AcknowledgeAlarm(AcknowledgeAlarmRequest)
@@ -28,5 +29,5 @@ message BypassAlarmRequest {
 message SnoozeAlarmRequest {
   repeated string devices = 1;
   string user = 2;
-  int64 duration_seconds = 3;
+  google.protobuf.Timestamp wake = 3;
 }


### PR DESCRIPTION
Swapped the snooze duration for a snooze wake time. This keeps our interface in line with what Phoebus is doing by default, and allows us to simplify some of our calculations by just doing a date comparison rather than having to run an actual timer.