### PR TITLE
:sparkles: add plot config API

### DIFF
--- a/proto/controls/service/DevDB/v1/DevDB.proto
+++ b/proto/controls/service/DevDB/v1/DevDB.proto
@@ -25,16 +25,6 @@ service DevDB {
 	returns (PlotConfigResult) {}
     rpc saveUserPlotConfiguration(PlotConfig)
 	returns (PlotConfigResult) {}
-
-    // This function allows clients to monitor device info changes.
-    // The client passes an array of device names. The function
-    // returns a stream which will report all changes to the device's
-    // information until the stream is canceled. The client will
-    // receive a complete set of device information before monitoring
-    // changes so there's no need to do an initial call to
-    // `getDeviceInfo()`.
-
-    // rpc monitorDeviceInfo(DeviceList) returns (stream InfoEntry) {}
 }
 
 message PlotSelector {

--- a/proto/controls/service/DevDB/v1/DevDB.proto
+++ b/proto/controls/service/DevDB/v1/DevDB.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package services.devdb;
 
+import "google/protobuf/empty.proto";
+
 service DevDB {
     // Clients can ask for device information (obtained from the
     // device database.) The function is passed an array of device
@@ -11,6 +13,18 @@ service DevDB {
     rpc getDeviceInfo(DeviceList) returns (DeviceInfoReply) {}
     rpc getAllAlarmInfo(DeviceList) returns (AlarmInfoReply) {}
     rpc getAlarmText(AlarmTextIdList) returns (DeviceAlarmTextList) {}
+
+    // These functions implement the plotting app API to manage plot
+    // configurations.
+
+    rpc getPlotConfiguration(PlotSelector)
+	returns (PlotConfigResult) {}
+    rpc getUserPlotConfiguration(google.protobuf.Empty)
+	returns (PlotConfigResult) {}
+    rpc savePlotConfiguration(PlotConfigSpecification)
+	returns (PlotConfigResult) {}
+    rpc saveUserPlotConfiguration(PlotConfig)
+	returns (PlotConfigResult) {}
 
     // This function allows clients to monitor device info changes.
     // The client passes an array of device names. The function
@@ -23,6 +37,25 @@ service DevDB {
     // rpc monitorDeviceInfo(DeviceList) returns (stream InfoEntry) {}
 }
 
+message PlotSelector {
+    string name = 1;
+}
+
+message PlotConfigSpecification {
+    string name = 1;
+    string config = 2;
+}
+
+message PlotConfig {
+    string config = 1;
+}
+
+message PlotConfigResult {
+    oneof result {
+	string config = 1;
+	string errMsg = 2;
+    }
+}
 
 // Holds an array of device names (strings).
 message DeviceList {
@@ -142,7 +175,7 @@ message DeviceDigitalAlarm{
 
 message DeviceAnalogAlarm {
     uint32 di = 1;
-    uint32 alarm_text_id = 2;        
+    uint32 alarm_text_id = 2;
 }
 
 message AlarmTextIdList {

--- a/proto/controls/service/DevDB/v1/DevDB.proto
+++ b/proto/controls/service/DevDB/v1/DevDB.proto
@@ -21,6 +21,8 @@ service DevDB {
 	returns (PlotConfigResult) {}
     rpc getUserPlotConfiguration(google.protobuf.Empty)
 	returns (PlotConfigResult) {}
+    rpc deletePlotConfiguration(PlotSelector)
+	returns (PlotConfigResult) {}
     rpc savePlotConfiguration(PlotConfigSpecification)
 	returns (PlotConfigResult) {}
     rpc saveUserPlotConfiguration(PlotConfig)
@@ -28,12 +30,17 @@ service DevDB {
 }
 
 message PlotSelector {
-    string name = 1;
+    optional uint32 id = 1;
 }
 
 message PlotConfigSpecification {
-    string name = 1;
-    string config = 2;
+    uint32 id = 1;
+    string name = 2;
+    string config = 3;
+}
+
+message PlotConfigResults {
+    repeated PlotConfigSpecification data = 1;
 }
 
 message PlotConfig {
@@ -42,8 +49,9 @@ message PlotConfig {
 
 message PlotConfigResult {
     oneof result {
-	string config = 1;
-	string errMsg = 2;
+	PlotConfigResults config = 1;
+        PlotConfig user_config = 2;
+	string errMsg = 3;
     }
 }
 


### PR DESCRIPTION
This PR adds four endpoints to manage plot configurations. These are needed by the new Plotting App.

Two endpoint get and set a named plot configuration. Two others get and set a user's default configuration. The user account is obtained from the JWT. A client without a JWT cannot interact with the user config API.