### PR TITLE
Add TakeActiveAlarmSnapshot RPC and response message

### DIFF
--- a/proto/controls/service/grpc-alarm-commands/v1/alarm_commands.proto
+++ b/proto/controls/service/grpc-alarm-commands/v1/alarm_commands.proto
@@ -18,7 +18,7 @@ service AlarmCommands {
       returns (google.protobuf.Empty);
 
   rpc TakeActiveAlarmSnapshot(google.protobuf.Empty) 
-      returns ActiveAlarmSnapshotResponse;
+      returns (ActiveAlarmSnapshotResponse);
 }
 
 message AcknowledgeAlarmRequest {
@@ -27,7 +27,7 @@ message AcknowledgeAlarmRequest {
 }
 
 message ActiveAlarmSnapshotResponse {
-  repeated common.alarm.Status active_alarms;
+  repeated common.alarm.Status active_alarms = 1;
 }
 
 message BypassAlarmRequest {

--- a/proto/controls/service/grpc-alarm-commands/v1/alarm_commands.proto
+++ b/proto/controls/service/grpc-alarm-commands/v1/alarm_commands.proto
@@ -5,6 +5,8 @@ package services.alarm_commands.v1;
 import "google/protobuf/empty.proto";
 import "google/protobuf/timestamp.proto";
 
+import "proto/controls/common/v1/alarm.proto";
+
 service AlarmCommands {
   rpc AcknowledgeAlarm(AcknowledgeAlarmRequest)
       returns (google.protobuf.Empty);
@@ -14,11 +16,18 @@ service AlarmCommands {
 
   rpc SnoozeAlarm(SnoozeAlarmRequest)
       returns (google.protobuf.Empty);
+
+  rpc TakeActiveAlarmSnapshot(google.protobuf.Empty) 
+      returns ActiveAlarmSnapshotResponse;
 }
 
 message AcknowledgeAlarmRequest {
   repeated string devices = 1;
   string user = 2;
+}
+
+message ActiveAlarmSnapshotResponse {
+  repeated common.alarm.Status active_alarms;
 }
 
 message BypassAlarmRequest {


### PR DESCRIPTION
Added TakeActiveAlarmSnapshot RPC and ActiveAlarmSnapshotResponse message.

The idea is that the alarms service will provide access to its internal cache of alarms, which should be curated to only have a single entry for each device/alarm type combo. Its implementation of the RPC could then filter out any inactive alarms before returning the results. This bypasses the need to filter out duplicates and "Ok" alarms from the Kafka stream (as we won't be using a Kafka stream for this snapshot anymore) and reduces the GraphQL API's dependency on Kafka (still need it for streaming new alarms, but the snapshot feature is moved to gRPC).