### PR TITLE
Add Activate command for alarms

### DIFF
--- a/proto/controls/service/grpc-alarm-commands/v1/alarm_commands.proto
+++ b/proto/controls/service/grpc-alarm-commands/v1/alarm_commands.proto
@@ -1,32 +1,40 @@
 syntax = "proto3";
 
-package services.alarm_commands.v1;
+package services.alarm_commands;
 
 import "google/protobuf/empty.proto";
 import "google/protobuf/timestamp.proto";
 
 service AlarmCommands {
-  rpc AcknowledgeAlarm(AcknowledgeAlarmRequest)
+  rpc Acknowledge(AcknowledgeRequest)
+      returns (google.protobuf.Empty);
+      
+  rpc Activate(ActivateRequest)
       returns (google.protobuf.Empty);
 
-  rpc BypassAlarm(BypassAlarmRequest)
+  rpc Bypass(BypassRequest)
       returns (google.protobuf.Empty);
 
-  rpc SnoozeAlarm(SnoozeAlarmRequest)
+  rpc Snooze(SnoozeRequest)
       returns (google.protobuf.Empty);
 }
 
-message AcknowledgeAlarmRequest {
+message AcknowledgeRequest {
   repeated string devices = 1;
   string user = 2;
 }
 
-message BypassAlarmRequest {
+message ActivateRequest {
   repeated string devices = 1;
   string user = 2;
 }
 
-message SnoozeAlarmRequest {
+message BypassRequest {
+  repeated string devices = 1;
+  string user = 2;
+}
+
+message SnoozeRequest {
   repeated string devices = 1;
   string user = 2;
   google.protobuf.Timestamp wake = 3;


### PR DESCRIPTION
Added a new command to "activate" an alarm. This would be a user manually taking an alarm out of Bypass or Snooze.

Also did a small refactor of the API so we don't have "Alarm" in so many places. 