### PR TITLE
Add "Unbypassed" state for alarms

### DIFF
--- a/proto/controls/common/v1/alarm.proto
+++ b/proto/controls/common/v1/alarm.proto
@@ -24,6 +24,7 @@ message Status {
         STATE_BYPASSED      = 3;
         STATE_LATCHED       = 4;
         STATE_ACKNOWLEDGED  = 5;
+        STATE_UNBYPASSED    = 6;
     }
     State state = 3;                        //  required
 


### PR DESCRIPTION
When a user takes an alarm out of Bypass, or an alarm's Snooze timer hits 0, it would be useful to have a definite "Unbypassed" record get emitted by the alarms service. 

This serves several purposes: 

1. When an alarm comes out of Bypass, we won't know right away what it's "real" state should be. We'll need to wait for an update from Redis before we can start populating the Kafka topic with live data. 

2. The Sync service will need help understanding when to ignore updates from the other service after it sees a Bypass message. That is, if one side initiates a Bypass, the other side won't know right away and might still be emitting "live" data about that alarm. The Sync service will see that data from the other side, and it needs to know whether to treat it as legitimate or not. If there's a concrete "Unbypassed" state for it to watch for, it can know that any new messages coming from any source should be ignored until it sees that the Bypass has been removed.